### PR TITLE
Allocate userid to client

### DIFF
--- a/backend/backend/allocate_user_id.py
+++ b/backend/backend/allocate_user_id.py
@@ -1,0 +1,31 @@
+"""Module providing functionality to create a player and send their ID back to the client"""
+
+from backend.storage import Player
+import json
+import sys
+import cgitb
+
+cgitb.enable()
+
+
+def request_user_id(source=sys.stdin, output=sys.stdout):
+    """Entry point for the client sending username to server, server responds with clients id.
+
+    >>> import io
+    >>> inp = io.StringIO(json.dumps({'username': 'testuser'}))
+    >>> out = io.StringIO()
+    >>> request_userID(inp,out)
+    >>> out.seek(0)
+    0
+    >>> print(Player("testuser"))
+    testuser: []
+    >>> print(out.read()) # doctest: +ELLIPSIS
+    Content-Type: application/json
+    <BLANKLINE>
+    {"your_username": "testuser", "your_id": testuser.user_id}
+    """
+    request = json.load(source)
+    client_username = request["username"]
+    player = Player(client_username)
+    output.write('Content-Type: application/json\n\n')
+    json.dump({"your_username": client_username, "your_id": player.user_id}, output)

--- a/backend/backend/allocate_user_id.py
+++ b/backend/backend/allocate_user_id.py
@@ -4,8 +4,17 @@ from backend.storage import Player
 import json
 import sys
 import cgitb
+from json import JSONEncoder
+from uuid import UUID
 
 cgitb.enable()
+
+"""
+Deals with no UUID serialization support in json. Casts the UUID to String.
+"""
+def JSONEncoder(uuidObject):
+    if isinstance(uuidObject, UUID):
+        return str(uuidObject)
 
 
 def request_user_id(source=sys.stdin, output=sys.stdout):
@@ -14,18 +23,16 @@ def request_user_id(source=sys.stdin, output=sys.stdout):
     >>> import io
     >>> inp = io.StringIO(json.dumps({'username': 'testuser'}))
     >>> out = io.StringIO()
-    >>> request_userID(inp,out)
+    >>> test = request_user_id(inp,out)
     >>> out.seek(0)
     0
-    >>> print(Player("testuser"))
-    testuser: []
     >>> print(out.read()) # doctest: +ELLIPSIS
     Content-Type: application/json
     <BLANKLINE>
-    {"your_username": "testuser", "your_id": testuser.user_id}
+    {"your_username": "testuser", "your_id": ...}
     """
     request = json.load(source)
     client_username = request["username"]
     player = Player(client_username)
     output.write('Content-Type: application/json\n\n')
-    json.dump({"your_username": client_username, "your_id": player.user_id}, output)
+    json.dump({"your_username": client_username, "your_id": JSONEncoder(player.user_id)}, output)

--- a/backend/backend/allocate_user_id.py
+++ b/backend/backend/allocate_user_id.py
@@ -1,24 +1,26 @@
-"""Module providing functionality to create a player and send their ID back to the client"""
+"""Module providing functionality to create a player and send their ID back to
+    the client"""
 
-from backend.storage import Player
 import json
 import sys
 import cgitb
-from json import JSONEncoder
 from uuid import UUID
+from backend.storage import Player
 
 cgitb.enable()
 
-"""
-Deals with no UUID serialization support in json. Casts the UUID to String.
-"""
-def JSONEncoder(uuidObject):
-    if isinstance(uuidObject, UUID):
-        return str(uuidObject)
+
+def json_encoder(uuid_object):
+    """Deals with no UUID serialization support in json. Casts the UUID to String.
+    """
+    if isinstance(uuid_object, UUID):
+        return str(uuid_object)
+    return None
 
 
 def request_user_id(source=sys.stdin, output=sys.stdout):
-    """Entry point for the client sending username to server, server responds with clients username & id.
+    """Entry point for the client sending username to server, server responds
+    with clients username & id.
 
     >>> import io
     >>> inp = io.StringIO(json.dumps({'username': 'testuser'}))
@@ -35,4 +37,5 @@ def request_user_id(source=sys.stdin, output=sys.stdout):
     client_username = request["username"]
     player = Player(client_username)
     output.write('Content-Type: application/json\n\n')
-    json.dump({"your_username": client_username, "your_id": JSONEncoder(player.user_id)}, output)
+    json.dump({"your_username": client_username, "your_id":
+               json_encoder(player.user_id)}, output)

--- a/backend/backend/allocate_user_id.py
+++ b/backend/backend/allocate_user_id.py
@@ -9,7 +9,7 @@ cgitb.enable()
 
 
 def request_user_id(source=sys.stdin, output=sys.stdout):
-    """Entry point for the client sending username to server, server responds with clients id.
+    """Entry point for the client sending username to server, server responds with clients username & id.
 
     >>> import io
     >>> inp = io.StringIO(json.dumps({'username': 'testuser'}))

--- a/backend/backend/allocate_user_id.py
+++ b/backend/backend/allocate_user_id.py
@@ -31,11 +31,11 @@ def request_user_id(source=sys.stdin, output=sys.stdout):
     >>> print(out.read()) # doctest: +ELLIPSIS
     Content-Type: application/json
     <BLANKLINE>
-    {"your_username": "testuser", "your_id": ...}
+    {"your_id": ..., "your_username": "testuser"}
     """
     request = json.load(source)
     client_username = request["username"]
     player = Player(client_username)
     output.write('Content-Type: application/json\n\n')
     json.dump({"your_username": client_username, "your_id":
-               json_encoder(player.user_id)}, output)
+               json_encoder(player.user_id)}, output, sort_keys=True)

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -3,5 +3,5 @@ pages = {
     'request_dice_roll': 'backend.process_client_json:request_dice_roll',
     'receive_client_username':
     'backend.process_client_json:receive_client_username',
-    'allocate_user_id':'backend.allocate_user_id:request_user_id'
+    'allocate_user_id': 'backend.allocate_user_id:request_user_id'
 }

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -3,4 +3,5 @@ pages = {
     'request_dice_roll': 'backend.process_client_json:request_dice_roll',
     'receive_client_username':
     'backend.process_client_json:receive_client_username',
+    'allocate_user_id':'backend.allocate_user_id:request_user_id'
 }

--- a/backend/tests/test_allocate_user_id.py
+++ b/backend/tests/test_allocate_user_id.py
@@ -1,0 +1,16 @@
+import unittest
+import doctest
+import backend.allocate_user_id
+
+
+class TestRequestUserID(unittest.TestCase):
+    pass
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(backend.allocate_user_id))
+    return tests
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_allocate_user_id.py
+++ b/backend/tests/test_allocate_user_id.py
@@ -1,15 +1,16 @@
 import unittest
 import doctest
 import backend.allocate_user_id
-from backend.allocate_user_id import JSONEncoder
+from backend.allocate_user_id import json_encoder
 from backend.storage import Player
 
 
 class TestRequestUserID(unittest.TestCase):
 
-    def testEncoder(self):
+    def test_encoder(self):
         encodeTest = Player("username")
-        self.assertEqual(str(encodeTest.user_id), JSONEncoder(encodeTest.user_id))
+        self.assertEqual(str(encodeTest.user_id),
+                         json_encoder(encodeTest.user_id))
 
 
 def load_tests(loader, tests, ignore):

--- a/backend/tests/test_allocate_user_id.py
+++ b/backend/tests/test_allocate_user_id.py
@@ -9,8 +9,8 @@ class TestRequestUserID(unittest.TestCase):
 
     def test_encoder(self):
         encodetest = Player("username")
-        self.assertEqual(str(encodeTest.user_id),
-                         json_encoder(encodeTest.user_id))
+        self.assertEqual(str(encodetest.user_id),
+                         json_encoder(encodetest.user_id))
         self.assertEqual(None, json_encoder("test"))
 
 

--- a/backend/tests/test_allocate_user_id.py
+++ b/backend/tests/test_allocate_user_id.py
@@ -11,6 +11,7 @@ class TestRequestUserID(unittest.TestCase):
         encodeTest = Player("username")
         self.assertEqual(str(encodeTest.user_id),
                          json_encoder(encodeTest.user_id))
+        self.assertEqual(None, json_encoder("test"))
 
 
 def load_tests(loader, tests, ignore):

--- a/backend/tests/test_allocate_user_id.py
+++ b/backend/tests/test_allocate_user_id.py
@@ -8,7 +8,7 @@ from backend.storage import Player
 class TestRequestUserID(unittest.TestCase):
 
     def test_encoder(self):
-        encodeTest = Player("username")
+        encodetest = Player("username")
         self.assertEqual(str(encodeTest.user_id),
                          json_encoder(encodeTest.user_id))
         self.assertEqual(None, json_encoder("test"))

--- a/backend/tests/test_allocate_user_id.py
+++ b/backend/tests/test_allocate_user_id.py
@@ -1,10 +1,15 @@
 import unittest
 import doctest
 import backend.allocate_user_id
+from backend.allocate_user_id import JSONEncoder
+from backend.storage import Player
 
 
 class TestRequestUserID(unittest.TestCase):
-    pass
+
+    def testEncoder(self):
+        encodeTest = Player("username")
+        self.assertEqual(str(encodeTest.user_id), JSONEncoder(encodeTest.user_id))
 
 
 def load_tests(loader, tests, ignore):


### PR DESCRIPTION
Client can request a user id from allocate_user_id page. This creates a new player and replies to the client with their username and unique id. I had to add a separate function just to cast the uuid to a String as uuids are not serializable over json seemingly.