### PR TITLE
Proof of concept for Server-Sent Events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN cd /frontend; npm install; npm start && cp -r dist/* /var/www/html
 RUN cd /var/www/html/cgi-bin; find . -type f -not -name "*.py" -exec mv {} {}.py ';'
 RUN chmod -R 755 /var/www/html
 
+RUN touch /var/www/html/cgi-bin/turn_data.db
+RUN chmod 777 /var/www/html/cgi-bin/turn_data.db
+
 EXPOSE 80
 
 ENTRYPOINT ["/usr/sbin/apache2"]

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -1,6 +1,6 @@
 """Turn-related logic."""
-# import cgitb
-# cgitb.enable()
+import cgitb
+cgitb.enable()
 
 import time
 import sys

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -1,35 +1,39 @@
 """Turn-related logic."""
-import cgitb
-cgitb.enable()
-
 import time
 import sys
 import json
 import shelve
 
-def send_turn_notifications():
-    json_input = json.load(sys.stdin)
-    username = json_input['username']
-    create_user_entry(username)
+import cgitb
+cgitb.enable()
 
+def send_turn_notifications():
     print('Content-Type: text/event-stream')
     print('Cache-Control: no cache')
     print()
     while True:
         print('event: fuck')
-        print('data: {}'.format(json.dumps({'yourTurn': check_user_turn(username)})))
+        print('data: {}'.format(json.dumps({'activeTurn': get_user_turn()})))
         print()
 
         sys.stdout.flush()
         time.sleep(1)
 
-def create_user_entry(username):
+def create_user_entry():
+    json_input = json.load(sys.stdin)
+    username = json_input['username']
     with shelve.open('turn_data') as turn_data:
         if turn_data == {}:
-            turn_data[username] = True
-        else:
-            turn_data[username] = False
+            turn_data['order'] = []
+        order = turn_data['order']
+        order.append(username)
+        turn_data['order'] = order
 
-def check_user_turn(username):
-    with shelve.open('turn_data') as turn_data:
-        return turn_data[username]
+def get_user_turn():
+    try:
+        with shelve.open('turn_data') as turn_data:
+            if 'order' in turn_data:
+                return turn_data['order'][0]
+            return None
+    except:
+        return None

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -1,6 +1,6 @@
 """Turn-related logic."""
-import cgitb
-cgitb.enable()
+# import cgitb
+# cgitb.enable()
 
 import time
 

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -3,11 +3,15 @@
 # cgitb.enable()
 
 import time
+import sys
 
 def send_turn_notifications():
     print('Content-Type: text/event-stream')
     print('Cache-Control: no cache')
     print()
     while True:
+        print('event: fuck')
         print('data: It’s your turn!')
-        time.sleep(5)
+        print()
+
+        sys.stdout.flush()

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -4,6 +4,7 @@ cgitb.enable()
 
 import time
 import sys
+import json
 
 def send_turn_notifications():
     print('Content-Type: text/event-stream')
@@ -11,7 +12,7 @@ def send_turn_notifications():
     print()
     while True:
         print('event: fuck')
-        print('data: It is your turn!')
+        print('data: {}'.format(json.dumps({'yourTurn': True})))
         print()
 
         sys.stdout.flush()

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -39,3 +39,12 @@ def get_user_turn():
         if 'order' in turn_data:
             return turn_data['order'][0]
         return None
+
+def end_turn():
+    with shelve.open('turn_data') as turn_data:
+        order = turn_data['order']
+        order.rotate(1)
+        turn_data['order'] = order
+    print('Content-type: text/plain')
+    print()
+    print('Turn ended.')

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -33,10 +33,7 @@ def create_user_entry():
     print('Username registered.')
 
 def get_user_turn():
-    try:
-        with shelve.open('turn_data') as turn_data:
-            if 'order' in turn_data:
-                return turn_data['order'][0]
-            return None
-    except:
+    with shelve.open('turn_data') as turn_data:
+        if 'order' in turn_data:
+            return turn_data['order'][0]
         return None

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -9,6 +9,7 @@ import cgitb
 cgitb.enable()
 
 def send_turn_notifications():
+    """Notify a client every second whose turn it is."""
     print('Content-Type: text/event-stream')
     print('Cache-Control: no cache')
     print()
@@ -21,6 +22,7 @@ def send_turn_notifications():
         time.sleep(1)
 
 def create_user_entry():
+    """Add a user to the turn order."""
     json_input = json.load(sys.stdin)
     username = json_input['username']
     with shelve.open('turn_data') as turn_data:
@@ -35,12 +37,14 @@ def create_user_entry():
     print('Username registered.')
 
 def get_user_turn():
+    """Get the username of the player whose turn it is."""
     with shelve.open('turn_data') as turn_data:
         if 'order' in turn_data:
             return turn_data['order'][0]
         return None
 
 def end_turn():
+    """End the current turn."""
     with shelve.open('turn_data') as turn_data:
         order = turn_data['order']
         order.rotate(1)

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -15,3 +15,4 @@ def send_turn_notifications():
         print()
 
         sys.stdout.flush()
+        time.sleep(1)

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -3,6 +3,7 @@ import time
 import sys
 import json
 import shelve
+from collections import deque
 
 import cgitb
 cgitb.enable()
@@ -24,7 +25,8 @@ def create_user_entry():
     username = json_input['username']
     with shelve.open('turn_data') as turn_data:
         if turn_data == {}:
-            turn_data['order'] = []
+            # if there is no turn data yet, create a queue
+            turn_data['order'] = deque()
         order = turn_data['order']
         order.append(username)
         turn_data['order'] = order

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -1,0 +1,11 @@
+"""Turn-related logic."""
+
+import time
+
+def send_turn_notifications():
+    print('Content-Type: text/event-stream')
+    print('Cache-Control: no cache')
+    print()
+    while True:
+        print('data: It’s your turn!')
+        time.sleep(5)

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -5,15 +5,31 @@ cgitb.enable()
 import time
 import sys
 import json
+import shelve
 
 def send_turn_notifications():
+    json_input = json.load(sys.stdin)
+    username = json_input['username']
+    create_user_entry(username)
+
     print('Content-Type: text/event-stream')
     print('Cache-Control: no cache')
     print()
     while True:
         print('event: fuck')
-        print('data: {}'.format(json.dumps({'yourTurn': True})))
+        print('data: {}'.format(json.dumps({'yourTurn': check_user_turn(username)})))
         print()
 
         sys.stdout.flush()
         time.sleep(1)
+
+def create_user_entry(username):
+    with shelve.open('turn_data') as turn_data:
+        if turn_data == {}:
+            turn_data[username] = True
+        else:
+            turn_data[username] = False
+
+def check_user_turn(username):
+    with shelve.open('turn_data') as turn_data:
+        return turn_data[username]

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -1,4 +1,6 @@
 """Turn-related logic."""
+import cgitb
+cgitb.enable()
 
 import time
 

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -10,16 +10,21 @@ import cgitb
 cgitb.enable()
 
 def send_turn_notifications():
-    """Notify a client every second whose turn it is."""
+    """Get the user’s id and send them notifications."""
     print('Content-Type: text/event-stream')
     print('Cache-Control: no cache')
     print()
     data = cgi.FieldStorage()
-    print('data: {}'.format(data.getfirst('fuck')))
+    user_id = data.getfirst('id')
+    print('data: username: {}'.format(user_id))
     print()
+    notification_loop(user_id)
+
+def notification_loop(user_id):
+    """Notify a client every second whose turn it is."""
     while True:
         print('event: turn')
-        print('data: {}'.format(json.dumps({'activeTurn': get_user_turn()})))
+        print('data: {}'.format(json.dumps({'activeTurn': get_user_turn(), 'username': user_id})))
         print()
 
         sys.stdout.flush()

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -13,7 +13,7 @@ def send_turn_notifications():
     print('Cache-Control: no cache')
     print()
     while True:
-        print('event: fuck')
+        print('event: turn')
         print('data: {}'.format(json.dumps({'activeTurn': get_user_turn()})))
         print()
 

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -4,6 +4,7 @@ import sys
 import json
 import shelve
 from collections import deque
+import cgi
 
 import cgitb
 cgitb.enable()
@@ -12,6 +13,9 @@ def send_turn_notifications():
     """Notify a client every second whose turn it is."""
     print('Content-Type: text/event-stream')
     print('Cache-Control: no cache')
+    print()
+    data = cgi.FieldStorage()
+    print('data: {}'.format(data.getfirst('fuck')))
     print()
     while True:
         print('event: turn')

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -28,6 +28,9 @@ def create_user_entry():
         order = turn_data['order']
         order.append(username)
         turn_data['order'] = order
+    print('Content-type: text/plain')
+    print()
+    print('Username registered.')
 
 def get_user_turn():
     try:

--- a/backend/backend/turn.py
+++ b/backend/backend/turn.py
@@ -11,7 +11,7 @@ def send_turn_notifications():
     print()
     while True:
         print('event: fuck')
-        print('data: It’s your turn!')
+        print('data: It is your turn!')
         print()
 
         sys.stdout.flush()

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -1,5 +1,5 @@
 pages = {
-    'example.py': 'backend.example:example',
-    'request_dice_roll.py': 'backend.process_client_json:request_dice_roll',
-    'notify_turn.py': 'backend.turn:send_turn_notifications',
+    'example': 'backend.example:example',
+    'request_dice_roll': 'backend.process_client_json:request_dice_roll',
+    'notify_turn': 'backend.turn:send_turn_notifications',
 }

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -3,4 +3,5 @@ pages = {
     'request_dice_roll': 'backend.process_client_json:request_dice_roll',
     'notify_turn': 'backend.turn:send_turn_notifications',
     'create_user_entry': 'backend.turn:create_user_entry',
+    'end_turn': 'backend.turn:end_turn',
 }

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -1,4 +1,5 @@
 pages = {
     'example': 'backend.example:example',
     'request_dice_roll': 'backend.process_client_json:request_dice_roll',
+    'notify_turn': 'backend.turn:send_turn_notifications',
 }

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -2,4 +2,5 @@ pages = {
     'example': 'backend.example:example',
     'request_dice_roll': 'backend.process_client_json:request_dice_roll',
     'notify_turn': 'backend.turn:send_turn_notifications',
+    'create_user_entry': 'backend.turn:create_user_entry',
 }

--- a/backend/pages.py
+++ b/backend/pages.py
@@ -1,5 +1,5 @@
 pages = {
-    'example': 'backend.example:example',
-    'request_dice_roll': 'backend.process_client_json:request_dice_roll',
-    'notify_turn': 'backend.turn:send_turn_notifications',
+    'example.py': 'backend.example:example',
+    'request_dice_roll.py': 'backend.process_client_json:request_dice_roll',
+    'notify_turn.py': 'backend.turn:send_turn_notifications',
 }

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -22,13 +22,14 @@ window.onload = () => {
         eventSource.addEventListener('message', (message) => {
             console.log(`SSE message: ${message.data}`)
         });
+        let turnCounter = 0;
         eventSource.addEventListener('fuck', (message) => {
             console.log(`SSE event of type fuck: ${message.data}`);
             const activeTurn = JSON.parse(message.data).activeTurn;
             const username = document.querySelector('#username').value;
-            console.log(`Comparing username (${username}) with active turn (${activeTurn})`)
-            if (activeTurn == document.querySelector('#username').value) {
+            if (activeTurn == document.querySelector('#username').value && ++turnCounter == 5) {
                 console.log('Ending turn');
+                turnCounter = 0;
                 sendJSON.sendJSON({
                     jsonObject: {},
                     serverAddress: 'cgi-bin/end_turn.py',

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -15,6 +15,7 @@ window.onload = () => {
 
     let eventSource = new EventSource('cgi-bin/notify_turn.py');
     eventSource.onopen = () => {
+        console.log('opened!');
         eventSource.addEventListener('error', (error) => {
             console.log(`SSE error: ${error.type}`);
         });

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -13,20 +13,30 @@ window.onload = () => {
         });
     };
 
+    // The event source receives notifications from the server
     let eventSource = new EventSource('cgi-bin/notify_turn.py');
+
+    // Once the event source has opened successfully:
     eventSource.onopen = () => {
         console.log('opened!');
+
+        // Add a listener to log errors
         eventSource.addEventListener('error', (error) => {
             console.log(`SSE error: ${error.type}`);
         });
+
+        // Add a listener to log messages
         eventSource.addEventListener('message', (message) => {
             console.log(`SSE message: ${message.data}`)
         });
+
         let turnCounter = 0;
+        // Add a listener to handle turn notifications
         eventSource.addEventListener('turn', (message) => {
             console.log(`SSE event of type turn: ${message.data}`);
             const activeTurn = JSON.parse(message.data).activeTurn;
             const username = document.querySelector('#username').value;
+            // End the turn if it’s yours and you’ve been notified 5 times
             if (activeTurn == document.querySelector('#username').value && ++turnCounter == 5) {
                 console.log('Ending turn');
                 turnCounter = 0;
@@ -39,6 +49,7 @@ window.onload = () => {
         });
     };
 
+    // Add user to the turn order when they submit their username
     document.querySelector('#usernameInput').onclick = (click) => {
         click.preventDefault();
         sendJSON.sendJSON({

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -12,4 +12,14 @@ window.onload = () => {
             }
         });
     };
+
+    let eventSource = new EventSource('cgi-bin/notify_turn.py');
+    eventSource.onopen = () => {
+        eventSource.addEventListener('error', () => {
+            console.log('SSE error.');
+        });
+        eventSource.addEventListener('message', (message) => {
+            console.log(`SSE message: ${message.data}`)
+        });
+    };
 };

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -22,5 +22,8 @@ window.onload = () => {
         eventSource.addEventListener('message', (message) => {
             console.log(`SSE message: ${message.data}`)
         });
+        eventSource.addEventListener('fuck', (message) => {
+            console.log(`SSE event of type fuck: ${message.data}`);
+        });
     };
 };

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -15,8 +15,8 @@ window.onload = () => {
 
     let eventSource = new EventSource('cgi-bin/notify_turn.py');
     eventSource.onopen = () => {
-        eventSource.addEventListener('error', () => {
-            console.log('SSE error.');
+        eventSource.addEventListener('error', (error) => {
+            console.log(`SSE error: ${error.type}`);
         });
         eventSource.addEventListener('message', (message) => {
             console.log(`SSE message: ${message.data}`)

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -26,4 +26,13 @@ window.onload = () => {
             console.log(`SSE event of type fuck: ${message.data}`);
         });
     };
+
+    document.querySelector('#usernameInput').onclick = (click) => {
+        click.preventDefault();
+        sendJSON.sendJSON({
+            jsonObject: {'username': document.querySelector('#username').value},
+            serverAddress: 'create_user_entry.py',
+            callback: () => {}
+        });
+    };
 };

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -24,6 +24,17 @@ window.onload = () => {
         });
         eventSource.addEventListener('fuck', (message) => {
             console.log(`SSE event of type fuck: ${message.data}`);
+            const activeTurn = JSON.parse(message.data).activeTurn;
+            const username = document.querySelector('#username').value;
+            console.log(`Comparing username (${username}) with active turn (${activeTurn})`)
+            if (activeTurn == document.querySelector('#username').value) {
+                console.log('Ending turn');
+                sendJSON.sendJSON({
+                    jsonObject: {},
+                    serverAddress: 'cgi-bin/end_turn.py',
+                    callback: () => {}
+                });
+            }
         });
     };
 

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -23,8 +23,8 @@ window.onload = () => {
             console.log(`SSE message: ${message.data}`)
         });
         let turnCounter = 0;
-        eventSource.addEventListener('fuck', (message) => {
-            console.log(`SSE event of type fuck: ${message.data}`);
+        eventSource.addEventListener('turn', (message) => {
+            console.log(`SSE event of type turn: ${message.data}`);
             const activeTurn = JSON.parse(message.data).activeTurn;
             const username = document.querySelector('#username').value;
             if (activeTurn == document.querySelector('#username').value && ++turnCounter == 5) {

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -31,7 +31,7 @@ window.onload = () => {
         click.preventDefault();
         sendJSON.sendJSON({
             jsonObject: {'username': document.querySelector('#username').value},
-            serverAddress: 'create_user_entry.py',
+            serverAddress: 'cgi-bin/create_user_entry.py',
             callback: () => {}
         });
     };

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -28,7 +28,7 @@ window.onload = () => {
         });
 
         // The event source receives notifications from the server
-        let eventSource = new EventSource(`cgi-bin/notify_turn.py?fuck=${username}`);
+        let eventSource = new EventSource(`cgi-bin/notify_turn.py?id=${username}`);
 
         // Once the event source has opened successfully:
         eventSource.onopen = () => {

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -13,49 +13,53 @@ window.onload = () => {
         });
     };
 
-    // The event source receives notifications from the server
-    let eventSource = new EventSource('cgi-bin/notify_turn.py');
 
-    // Once the event source has opened successfully:
-    eventSource.onopen = () => {
-        console.log('opened!');
-
-        // Add a listener to log errors
-        eventSource.addEventListener('error', (error) => {
-            console.log(`SSE error: ${error.type}`);
-        });
-
-        // Add a listener to log messages
-        eventSource.addEventListener('message', (message) => {
-            console.log(`SSE message: ${message.data}`)
-        });
-
-        let turnCounter = 0;
-        // Add a listener to handle turn notifications
-        eventSource.addEventListener('turn', (message) => {
-            console.log(`SSE event of type turn: ${message.data}`);
-            const activeTurn = JSON.parse(message.data).activeTurn;
-            const username = document.querySelector('#username').value;
-            // End the turn if it’s yours and you’ve been notified 5 times
-            if (activeTurn == document.querySelector('#username').value && ++turnCounter == 5) {
-                console.log('Ending turn');
-                turnCounter = 0;
-                sendJSON.sendJSON({
-                    jsonObject: {},
-                    serverAddress: 'cgi-bin/end_turn.py',
-                    callback: () => {}
-                });
-            }
-        });
-    };
 
     // Add user to the turn order when they submit their username
     document.querySelector('#usernameInput').onclick = (click) => {
         click.preventDefault();
+
+        const username = document.querySelector('#username').value;
+
         sendJSON.sendJSON({
-            jsonObject: {'username': document.querySelector('#username').value},
+            jsonObject: {'username': username},
             serverAddress: 'cgi-bin/create_user_entry.py',
             callback: () => {}
         });
+
+        // The event source receives notifications from the server
+        let eventSource = new EventSource(`cgi-bin/notify_turn.py?fuck=${username}`);
+
+        // Once the event source has opened successfully:
+        eventSource.onopen = () => {
+            console.log('opened!');
+
+            // Add a listener to log errors
+            eventSource.addEventListener('error', (error) => {
+                console.log(`SSE error: ${error.type}`);
+            });
+
+            // Add a listener to log messages
+            eventSource.addEventListener('message', (message) => {
+                console.log(`SSE message: ${message.data}`)
+            });
+
+            let turnCounter = 0;
+            // Add a listener to handle turn notifications
+            eventSource.addEventListener('turn', (message) => {
+                console.log(`SSE event of type turn: ${message.data}`);
+                const activeTurn = JSON.parse(message.data).activeTurn;
+                // End the turn if it’s yours and you’ve been notified 5 times
+                if (activeTurn == username && ++turnCounter == 5) {
+                    console.log('Ending turn');
+                    turnCounter = 0;
+                    sendJSON.sendJSON({
+                        jsonObject: {},
+                        serverAddress: 'cgi-bin/end_turn.py',
+                        callback: () => {}
+                    });
+                }
+            });
+        };
     };
 };

--- a/frontend/app/sendJSON.js
+++ b/frontend/app/sendJSON.js
@@ -1,13 +1,29 @@
 // Generate JSON to send to server on game start.
 export function generateGameStartJSON() {
-    return JSON.stringify({type: 'gameStart'});
+    return {type: 'gameStart'};
 }
 
 // Send a POST request to the server for the game start.
 export function gameStartRequest(serverAddress, callback) {
+    sendJSON({
+        'jsonObject': generateGameStartJSON(),
+        'serverAddress': serverAddress,
+        'callback': callback
+    });
+}
+
+/**
+ * Sends a JSON ajax request.
+ *
+ * @param {Object} jsonObject The object to stringify and send as JSON.
+ * @param {String} serverAddress The address to the send the request to.
+ * @param {Function} callback The callback that will be called when the ajax
+ *        request’s readystate changes.
+ */
+export function sendJSON({jsonObject, serverAddress, callback}) {
     const ajaxRequest = new XMLHttpRequest();
     ajaxRequest.open('POST', serverAddress, true);
     ajaxRequest.onreadystatechange = () => callback(ajaxRequest);
     ajaxRequest.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-    ajaxRequest.send(generateGameStartJSON());
+    ajaxRequest.send(JSON.stringify(jsonObject));
 }

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -14,7 +14,7 @@
 		  Username:<br>
 		  <input type="text" id="username">
 		  <br>
-		  <input type="submit" value="Submit" id="usernameInput">
+		  <button id="usernameInput">Submit</button>
 		</form>
 		<br>
 		<!--Change attributes according to function call -->

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -15,10 +15,11 @@
 		  <input type="text" id="username">
 		  <br>
 		  <input type="submit" value="Submit" id="usernameInput">
-		</form> 
+		</form>
 		<br>
 		<!--Change attributes according to function call -->
 		<button type="button" id="roll_die">Roll die</button>
+		<section class="turnDisplay"></section>
 	</body>
 
 </html>


### PR DESCRIPTION
- All clients are notified every 3 seconds of whose turn it is.
- When clients enter their username and hit submit, they are added to the turn order.
- Each client ends its turn after 5 notifications.

With SSE you can either send events, which have a name/type and some data, or messages, which only have data. You add event listeners either for messages or for specific events.

At the moment, all clients are listening to the same notifications, but it could be changed so the server sends notifications as events using the user IDs, and then each user could just listen for its own ID. I think it would still be receiving the other notifications and doing nothing with them, but I anticipate we’ll be sending events to everyone or most people more often than to individuals.

The other issue is having different streams for different games. I haven’t tried it, but I think we can solve this by including the game ID in the query string for the event source entry point, and using that in the file/database lookup.