### PR TITLE
Modify checkButton.js to not interact with checkboxes

### DIFF
--- a/frontend/app/checkButton.js
+++ b/frontend/app/checkButton.js
@@ -1,30 +1,23 @@
-// returns true if the username textbox contains no value, otherwise false
-export function checkTextField(username) {
-    const usernameValue = username.value;
-    if (usernameValue !== null && usernameValue.trim() !== '') {
-        return false;
-    } else if (usernameValue === null || usernameValue.trim() === '') {
-        return true;
-    }
-
-    return true;
-}
-
-// disables username textbox and enables submit button if username contains a value,
-// otherwise does the opposite
-export function boxChecked() {
+// Display an error message if username is invalid or empty, otherwise show
+// a confirmation message and enable the submit button
+export function checkTextField() {
     const username = document.querySelector('#username');
-    const confirmUsername = document.querySelector('#confirm_username');
+    const usernameValue = username.value;
+    // Select the span element in which a confirmation message is displayed
     const checker = document.querySelector('#checker');
-    if (confirmUsername.checked) {
-        if (!checkTextField(username)) {
-            username.disabled = true;
-            confirmUsername.disabled = true;
-            document.getElementById('submit_username').disabled = false;
-            checker.innerHTML = 'Username is confirmed';
-        } else {
-            checker.innerHTML = 'Username hasn\'t been entered';
-        }
+    // Check if username has typed a valid username
+    if (usernameValue !== null && usernameValue.trim() !== '') {
+        username.disabled = true;
+        document.getElementById('submit_username').disabled = false;
+        checker.innerHTML = 'Username is confirmed';
+    } else {
+        checker.innerHTML = 'Username hasn\'t been entered';
     }
 }
 
+// Adds an event listener to the username text field in the new user html page
+// which is called when the user clicks outside the text field
+export function validateUsername(callback = checkTextField) {
+    const username = document.querySelector('#username');
+    username.addEventListener('change', callback, false);
+}

--- a/frontend/app/checkButton.test.js
+++ b/frontend/app/checkButton.test.js
@@ -1,104 +1,70 @@
 import * as checkButton from './checkButton';
 
-describe('checkTextField should return false since username is populated', () => {
-    let usernameTextField;
-    // Setup function create mock text field
+describe('checkTextField should succeed with populated username field', () => {
+    const oldDocumentBody = document.body;
+
     beforeAll(() => {
-        // Create a mock populated text field to pass to checkTextField
-        usernameTextField = document.createElement('input');
-        usernameTextField.type = 'text';
-        usernameTextField.id = 'username';
-        usernameTextField.value = 'testuser';
-    });
-
-    // This is the actual test which calls the JavaScript and compares the
-    // return value with 'false'.
-    test('should successfully detect username text and return false', () => {
-        expect(checkButton.checkTextField(usernameTextField)).toBe(false);
-    });
-});
-
-describe('checkTextField should return true since username is not populated', () => {
-    let usernameTextField;
-    // Setup function create mock text field
-    beforeAll(() => {
-        // Create a mock un-populated text field to pass to checkTextField
-        usernameTextField = document.createElement('input');
-        usernameTextField.type = 'text';
-        usernameTextField.id = 'username';
-    });
-
-    test('should find blank username field and return true', () => {
-        expect(checkButton.checkTextField(usernameTextField)).toBe(true);
-    });
-});
-
-describe('boxChecked confirms checkUsername box is checked and username field is populated', () => {
-    let oldBody;
-    // Setup function create mock HTML page
-    beforeAll(() => {
-        // Create a mock HTML page body with the username field populated and
-        // confirm_username checkbox is checked.
-        oldBody = document.body.innerHTML;
-        document.body.innerHTML = '<form><label for="username">Username:</label><input type="text" id="username" maxlength="20" value="testuser"><input type="checkbox" name="confirm_username" id="confirm_username" checked><span id="checker">I have confirmed my username</span><input type="submit" value="Submit" id="submit_username" disabled></form>';
+        document.body.innerHTML = '<form><input type="text" id="username" value="testuser"><input type="submit" value="Submit" id="submit_username" disabled><span id="checker"></span></form>';
     });
 
     afterAll(() => {
-        // Restore HTML body to its state before the test
-        document.body.innerHTML = oldBody;
+        document.body = oldDocumentBody;
     });
 
-    // This test waits for all expect() functions to complete before exiting,
-    // hence it has done() at the end and takes a done parameter.
-    test('should disable the username text field, disable the confirm_username checkbox, enable the submit button, and place "Username is confirmed" into the checker span', (done) => {
-        checkButton.boxChecked();
-        expect(document.getElementById('username').disabled).toBe(true);
-        expect(document.getElementById('confirm_username').disabled).toBe(true);
-        expect(document.getElementById('submit_username').disabled).toBe(false);
-        expect(document.getElementById('checker').innerHTML).toEqual('Username is confirmed');
+    test('should display confirmation and enable submit button', () => {
+        checkButton.checkTextField();
+        expect(document.body.innerHTML).toEqual('<form><input type="text" id="username" value="testuser" disabled=""><input type="submit" value="Submit" id="submit_username"><span id="checker">Username is confirmed</span></form>');
+    });
+});
+
+describe('checkTextField should fail since username field unpopulated', () => {
+    const oldDocumentBody = document.body;
+
+    beforeAll(() => {
+        document.body.innerHTML = '<form><input type="text" id="username"><input type="submit" value="Submit" id="submit_username"><span id="checker"></span></form>';
+    });
+
+    afterAll(() => {
+        document.body = oldDocumentBody;
+    });
+
+    test('should display error message', () => {
+        checkButton.checkTextField();
+        expect(document.body.innerHTML).toEqual('<form><input type="text" id="username"><input type="submit" value="Submit" id="submit_username"><span id="checker">Username hasn\'t been entered</span></form>');
+    });
+});
+
+describe('checkTextField should fail since username field is all whitespaces', () => {
+    const oldDocumentBody = document.body;
+
+    beforeAll(() => {
+        document.body.innerHTML = '<form><input type="text" id="username" value="   "><input type="submit" value="Submit" id="submit_username"><span id="checker"></span></form>';
+    });
+
+    afterAll(() => {
+        document.body = oldDocumentBody;
+    });
+
+    test('should display error message', () => {
+        checkButton.checkTextField();
+        expect(document.body.innerHTML).toEqual('<form><input type="text" id="username" value="   "><input type="submit" value="Submit" id="submit_username"><span id="checker">Username hasn\'t been entered</span></form>');
+    });
+});
+
+describe('validateUsername should an event listener to username field', () => {
+    let eventListener;
+    let htmlUsername;
+
+    beforeAll(() => {
+        eventListener = jest.fn();
+        htmlUsername = document.createElement('input');
+        htmlUsername.type = 'text';
+        htmlUsername.id = 'username';
+    });
+
+    test('username should have event listener attached', (done) => {
+        checkButton.validateUsername(eventListener);
+        expect(eventListener).not.toHaveBeenCalled();
         done();
-    });
-});
-
-describe('boxChecked shows warning message due to unpopulated username field', () => {
-    let oldBody;
-    // Setup function create mock HTML page
-    beforeAll(() => {
-        // Create a mock HTML page body with the username field unpopulated and
-        // confirm_username checkbox is checked.
-        oldBody = document.body.innerHTML;
-        document.body.innerHTML = '<form><label for="username">Username:</label><input type="text" id="username" maxlength="20"><input type="checkbox" name="confirm_username" id="confirm_username" checked><span id="checker">I have confirmed my username</span><input type="submit" value="Submit" id="submit_username" disabled></form>';
-    });
-
-    afterAll(() => {
-        // Restore HTML body to its state before the test
-        document.body.innerHTML = oldBody;
-    });
-
-    // This test waits for all expect() functions to complete before exiting,
-    // hence it has done() at the end and takes a done parameter.
-    test('should place "Username hasn\'t been entered" into the checker span', (done) => {
-        checkButton.boxChecked();
-        expect(document.getElementById('checker').innerHTML).toEqual('Username hasn\'t been entered');
-        done();
-    });
-});
-
-describe('boxChecked takes no action due to confirm_username box unchecked', () => {
-    let oldBody;
-    // Setup function create mock HTML page
-    beforeAll(() => {
-        // Create a mock HTML page body with confirm_username checkbox left unchecked.
-        oldBody = document.body.innerHTML;
-        document.body.innerHTML = '<form><label for="username">Username:</label><input type="text" id="username" maxlength="20"><input type="checkbox" name="confirm_username" id="confirm_username"><span id="checker">I have confirmed my username</span><input type="submit" value="Submit" id="submit_username" disabled></form>';
-    });
-
-    afterAll(() => {
-        // Restore HTML body to its state before the test
-        document.body.innerHTML = oldBody;
-    });
-
-    test('should return undefined', () => {
-        expect(checkButton.boxChecked()).toEqual(undefined);
     });
 });

--- a/frontend/app/generateUsernameForm.js
+++ b/frontend/app/generateUsernameForm.js
@@ -8,7 +8,7 @@ export function requestUserID(serverAddress, nameSubmitted, callback) {
 }
 
 export function generateUsernameForm(callback) {
-    document.body.innerHTML = '<form><label for="username">Enter Username</label><input type="text" id="username"><input type="submit" value="Submit" id="submit_username" disabled></form>';
+    document.body.innerHTML = '<form><label for="username">Enter Username</label><input type="text" id="username"><input type="submit" value="Submit" id="submit_username" disabled><span id="checker"></span></form>';
     document.getElementById('submit_username').addEventListener('click', (event) => { event.preventDefault(); });
     document.getElementById('submit_username').onclick = () => requestUserID('cgi-bin/allocate_user_id.py', document.getElementById('username').value, callback);
 }

--- a/frontend/app/generateUsernameForm.test.js
+++ b/frontend/app/generateUsernameForm.test.js
@@ -37,7 +37,7 @@ describe('Generate form to the body of ', () => {
         const callback = jest.fn();
         usernameForm.generateUsernameForm(callback);
         expect(document.getElementById('submit_username').value).toEqual('Submit');
-        expect(document.body.innerHTML).toEqual('<form><label for="username">Enter Username</label><input type="text" id="username"><input type="submit" value="Submit" id="submit_username" disabled=""></form>');
+        expect(document.body.innerHTML).toEqual('<form><label for="username">Enter Username</label><input type="text" id="username"><input type="submit" value="Submit" id="submit_username" disabled=""><span id="checker"></span></form>');
         expect(document.getElementById('username').type).toEqual('text');
         done();
     });

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -2,6 +2,7 @@ import * as checkUserIDCookie from './checkUserIDCookie';
 import * as generateUsernameForm from './generateUsernameForm';
 import * as generateCreateJoinGamePage from './generateCreateJoinGamePage';
 import * as createUserCookie from './createUserCookie';
+import * as checkButton from './checkButton';
 
 
 window.onload = () => {
@@ -20,5 +21,6 @@ window.onload = () => {
                 generateCreateJoinGamePage.generateCreateJoinGamePage();
             }
         });
+        checkButton.validateUsername();
     }
 };


### PR DESCRIPTION
Instead of triggering validation when a checkbox is checked, validation is triggered when the text field loses focus (i.e when the user clicks away from the username textfield field), thanks to a suggestion by @gabystephanov . Everything seems in order at the moment but I'll comment again once the latest changes to master have been made.