### PR TITLE
Sleep SSE thread between database polling

### DIFF
--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -3,6 +3,7 @@ Handles the generation of Server-Sent Events which notify clients of state
 changes.
 """
 import sys
+import time
 import json
 from cgi import FieldStorage
 import cgitb
@@ -33,6 +34,7 @@ def start_sse_stream(output_stream=sys.stdout):
             generate_player_join_event(output_stream, players, new_players)
             players = new_players
 
+        time.sleep(3)
         output_stream.flush()
 
 


### PR DESCRIPTION
Without this, every SSE thread (1 per player) is polling the database non-stop, which leads to a very high load on the server and slow response to the users.