### PR TITLE
Fix sse balances error

### DIFF
--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -418,7 +418,7 @@ def generate_player_balance_event(output_stream, old_balances, new_balances):
             old = old_balances[uid]
             if old != balance:
                 data.append([uid, balance, balance - old])
-        else :
+        else:
             data.append([uid, balance, 0])
 
     output_stream.write(json.dumps(data))

--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -412,16 +412,16 @@ def generate_player_balance_event(output_stream, old_balances, new_balances):
     # with the two dictionaries.
     output_stream.write('data: ')
 
-    if not old_balances:
-        output_stream.write(json.dumps([
-            [uid, balance, 0]
-            for uid, balance in new_balances.items()]))
-    else:
-        output_stream.write(json.dumps([
-            [uid, balance, ((balance - old_balances[uid])
-                            if old_balances[uid] else balance)]
-            for uid, balance in new_balances.items()
-            if balance != old_balances[uid]]))
+    data = []
+    for uid, balance in new_balances.items():
+        if uid in old_balances:
+            old = old_balances[uid]
+            if old != balance:
+                data.append([uid, balance, balance - old])
+        else :
+            data.append([uid, balance, 0])
+
+    output_stream.write(json.dumps(data))
 
     # Standard SSE procedure to have two blank lines after data.
     output_stream.write('\n\n')

--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -396,6 +396,14 @@ def generate_player_balance_event(output_stream, old_balances, new_balances):
     data: [[5, 200, 0]]
     <BLANKLINE>
 
+    >>> import sys
+    >>> generate_player_balance_event(
+    ...     sys.stdout,
+    ...     {3: 100},
+    ...     {5: 200, 3: 100})
+    event: playerBalance
+    data: [[5, 200, 0]]
+    <BLANKLINE>
     """
     # Send the event name to the client.
     output_stream.write('event: playerBalance\n')

--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -317,6 +317,14 @@ def generate_player_move_event(output_stream, old_positions, new_positions):
     data: [[5, 4, 0]]
     <BLANKLINE>
 
+    >>> import sys
+    >>> generate_player_move_event(
+    ...     sys.stdout,
+    ...     {3: 10},
+    ...     {5: 4, 3: 10})
+    event: playerMove
+    data: [[5, 4, 0]]
+    <BLANKLINE>
     """
     # Send the event name to the client.
     output_stream.write('event: playerMove\n')
@@ -324,15 +332,17 @@ def generate_player_move_event(output_stream, old_positions, new_positions):
     # Send the JSON object which contains the elements that are not in common
     # with the two dictionaries.
     output_stream.write('data: ')
-    if not old_positions:
-        output_stream.write(json.dumps([
-            [uid, board_position, 0]
-            for uid, board_position in new_positions.items()]))
-    else:
-        output_stream.write(json.dumps([
-            [uid, board_position, old_positions[uid]]
-            for uid, board_position in new_positions.items()
-            if board_position != old_positions[uid]]))
+
+    data = []
+    for uid, new_position in new_positions.items():
+        if uid not in old_positions:
+            data.append([uid, new_position, 0])
+        else:
+            old_position = old_positions[uid]
+            if old_position != new_position:
+                data.append([uid, new_position, old_position])
+
+    output_stream.write(json.dumps(data))
 
     # Standard SSE procedure to have two blank lines after data.
     output_stream.write('\n\n')


### PR DESCRIPTION
This error was causing everyone to be duplicated in waiting games, because the event source was hitting a `KeyError` and then reconnecting and receiving the names again.

This passes the test I added, but I’m confirming that it’s fixed at the moment by testing through Docker.