### PR TITLE
Possible fix for aws.

### DIFF
--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -102,7 +102,7 @@ def start_sse_stream(output_stream=sys.stdout):
         last_game_state = check_game_playing_status(output_stream, game,
                                                     last_game_state)
 
-        time.sleep(0.5)
+        time.sleep(3)
 
         # Flush standard out which forcefully sends everything that might be
         # buffered in standard out to the client. No need to worry about tech


### PR DESCRIPTION
Changed time.sleep to 3 secs in order to give things time to load. Locally and on the AWS i have been experiencing lots of errors and non responsiveness with the game. Changing this to 3 secs allowed me to do things as normal. Will do further testing with times. 1 sec is also too quick. 2 secs work but i'm not if that will always be the case. So 3 secs is the safe option for now.