### PR TITLE
Include index file in pydoc generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,10 @@ RUN cd /frontend; npm install; npm start && cp -r dist/* /var/www/html
 RUN cd /var/www/html/cgi-bin; find . -type f -not -name "*.py" -exec mv {} {}.py ';'
 RUN chmod -R 755 /var/www/html
 
-RUN cd /backend/backend; find . -type f -name "*.py" -exec pydoc3 -w {} ';'; mkdir /var/www/html/pydoc;for filename in *.html; do mv $filename /var/www/html/pydoc/$filename; done
+#
+# Documentation on the server
+#
+RUN pydoc3 -w ./backend/; ln backend.html index.html; mkdir /var/www/html/pydoc;for filename in *.html; do mv "$filename" /var/www/html/pydoc/"$filename"; done
 RUN npm install -g jsdoc
 RUN cd /frontend; jsdoc ./app; mv out /var/www/html/jsdoc
 


### PR DESCRIPTION
By calling pydoc on the package instead of the individual files, we get an extra index page for the package.

I’ve also linked this file so that it’s available as index.html, which makes the link [url]/pydoc much more useful.