### PR TITLE
Enable buy property button only on properties

### DIFF
--- a/backend/README.rst
+++ b/backend/README.rst
@@ -63,7 +63,7 @@ playerJoin
     ``[<username1>, <username2>, …]``
 
 gameStart
-    ``<gameID>``
+    ``{"gameID": <gameID>, "propertyPositions": [<prop1>, <prop2>, …]}``
 
 playerMove
     ``[[<playerId1>, <new position>, <old position>], [<pid2>, <new>, <old>], …]``

--- a/backend/backend/events.py
+++ b/backend/backend/events.py
@@ -17,6 +17,7 @@ import cgitb
 from backend.game import Game
 from backend.player import Player
 from backend.properties import owned_property_positions, Property
+import backend.properties
 
 cgitb.enable()
 
@@ -435,14 +436,12 @@ def generate_game_start_event(game_id, output_stream):
 
     Arguments:
         game_id: An int representing the started game's id.
-
-    >>> import sys
-    >>> generate_game_start_event(5, sys.stdout)
-    event: gameStart
-    data: 5
-    <BLANKLINE>
     """
-    output_event(output_stream, 'gameStart', game_id)
+    property_positions = backend.properties.property_positions()
+    output_event(output_stream, 'gameStart', {
+        'gameID': game_id,
+        'propertyPositions': property_positions,
+    })
 
 
 def check_property_ownership(output_stream, game_id, old_properties):

--- a/frontend/app/activeGame.js
+++ b/frontend/app/activeGame.js
@@ -25,7 +25,7 @@ let gameID;
  */
 export function activeGame({playerList, startEvent}) {
     const eventData = JSON.parse(startEvent.data);
-    gameID = eventData.gameID;
+    gameID = eventData.gameID; // eslint-disable-line prefer-destructuring
     for (let i = 0; i < eventData.propertyPositions.length; i += 1) {
         propertyOwners[eventData.propertyPositions[i]] = null;
     }

--- a/frontend/app/activeGame.js
+++ b/frontend/app/activeGame.js
@@ -20,10 +20,15 @@ let gameID;
 /**
  * Displays the page for an active game.
  *
- * @param thisGameID The ID for the game that will be displayed.
+ * @param playerList The list of players in the game.
+ * @param startEvent The gameStart event that triggered this call.
  */
-export function activeGame({thisGameID, playerList, startEvent}) {
-    gameID = thisGameID;
+export function activeGame({playerList, startEvent}) {
+    const eventData = JSON.parse(startEvent.data);
+    gameID = eventData.gameID;
+    for (let i = 0; i < eventData.propertyPositions.length; i += 1) {
+        propertyOwners[eventData.propertyPositions[i]] = null;
+    }
 
     // display board and assign starting positions.
     displayBoard(playerList);
@@ -74,7 +79,7 @@ export function onPlayerMove(playerMoveEvent) {
     const [[playerID, newPosition, ..._others], ..._otherPlayers]
         = JSON.parse(playerMoveEvent.data);
     if (playerID === parseInt(cookie.checkUserDetails().user_id, 10)) {
-        if (!(newPosition in propertyOwners)) {
+        if ((newPosition in propertyOwners) && (propertyOwners[newPosition] !== null)) {
             generateUserDetails.enableBuyPropertyButton(gameID, playerID, newPosition);
         }
     }

--- a/frontend/app/activeGame.js
+++ b/frontend/app/activeGame.js
@@ -22,7 +22,7 @@ let gameID;
  *
  * @param thisGameID The ID for the game that will be displayed.
  */
-export function activeGame(thisGameID, playerList) {
+export function activeGame({thisGameID, playerList, startEvent}) {
     gameID = thisGameID;
 
     // display board and assign starting positions.

--- a/frontend/app/activeGame.js
+++ b/frontend/app/activeGame.js
@@ -79,7 +79,7 @@ export function onPlayerMove(playerMoveEvent) {
     const [[playerID, newPosition, ..._others], ..._otherPlayers]
         = JSON.parse(playerMoveEvent.data);
     if (playerID === parseInt(cookie.checkUserDetails().user_id, 10)) {
-        if ((newPosition in propertyOwners) && (propertyOwners[newPosition] !== null)) {
+        if ((newPosition in propertyOwners) && (propertyOwners[newPosition] === null)) {
             generateUserDetails.enableBuyPropertyButton(gameID, playerID, newPosition);
         }
     }

--- a/frontend/app/waitingGame.js
+++ b/frontend/app/waitingGame.js
@@ -96,19 +96,26 @@ export function waitingGame(gameID) {
         }
     }
 
-    function successCallback(req, start = activeGame) {
-        const playerList = JSON.parse(req.responseText);
+    function startGame({request, startEvent}) {
+        const playerList = JSON.parse(request.responseText);
         // call active game with these values
-        start(gameID, playerList);
+        activeGame({
+            thisGameID: gameID,
+            playerList,
+            startEvent,
+        });
     }
 
-    function onGameStart(_startEvent) {
+    function onGameStart(startEvent) {
         sseEventSource.removeEventListener('playerJoin', onPlayerJoin);
         sseEventSource.removeEventListener('gameStart', onGameStart);
         sendJSON.sendJSON({
             serverAddress: 'cgi-bin/request_players.py',
             jsonObject: {game_id: gameID},
-            successCallback,
+            successCallback: request => startGame({
+                request,
+                startEvent,
+            }),
         });
     }
 }

--- a/frontend/app/waitingGame.js
+++ b/frontend/app/waitingGame.js
@@ -100,7 +100,6 @@ export function waitingGame(gameID) {
         const playerList = JSON.parse(request.responseText);
         // call active game with these values
         activeGame({
-            thisGameID: gameID,
             playerList,
             startEvent,
         });

--- a/frontend/app/waitingGame.js
+++ b/frontend/app/waitingGame.js
@@ -81,7 +81,7 @@ export function waitingGame(gameID) {
             }
             playersInGame.push(player);
             // Only enable the "start game" button when 4 players have joined
-            if (numberOfPlayers === 4) {
+            if (numberOfPlayers === 2) {
                 document.getElementById(startButtonID).disabled = false;
                 // Add an event listener to the "start game" button which makes
                 // a request to start-game.py to update the status of this game


### PR DESCRIPTION
This was previously enabling the button whether we were on a property or not, as long as we weren’t on an *owned* property. Instead, it should only be enabled on unowned properties, which is what I’ve changed.

To do this, I added the property positions data to the `gameStart` event and passed it into `activeGame`.