### PR TITLE
Add primary key constraint to rolls table

### DIFF
--- a/initialise_server.sql
+++ b/initialise_server.sql
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS rolls (
     roll1 tinyint UNSIGNED NOT NULL,
     roll2 tinyint UNSIGNED NOT NULL,
     num int UNSIGNED NOT NULL,
-    FOREIGN KEY (id) REFERENCES players(id)
+    FOREIGN KEY (id) REFERENCES players(id),
+    PRIMARY KEY (id, num)
 );
 
 CREATE TABLE IF NOT EXISTS games (


### PR DESCRIPTION
This allows the `REPLACE INTO` statement we’re using for the rolls to function correctly, and avoids filling the table with a huge amount of duplicated data.